### PR TITLE
Lazily load flash messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,16 +217,19 @@ dependencies = [
 [[package]]
 name = "axum-messages"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e85c86a8bd84f54833bca296a0204bd865958ade62bacadeae92dda34cfb8a"
 dependencies = [
  "async-trait",
+ "axum",
  "axum-core",
  "http 1.1.0",
+ "http-body-util",
+ "hyper 1.5.0",
  "parking_lot",
  "serde",
  "serde_json",
+ "tokio",
  "tower 0.4.13",
+ "tower-sessions",
  "tower-sessions-core",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ async-trait = "0.1.83"
 axum = { version = "0.7.7", features = ["macros"] }
 axum-extra = { version = "0.9.4", features = ["typed-header"] }
 axum-login = "0.16.0"
-axum-messages = "0.7.0"
+#axum-messages = "0.7.0"
+axum-messages = { path = "axum-messages" }
 base64 = "0.22.1"
 chrono = "0.4.38"
 deadpool = "0.12.1"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -13,7 +13,8 @@ async-trait = "0.1.83"
 axum = "0.7.7"
 axum-extra = { version = "0.9.4", features = ["typed-header"] }
 axum-login = "0.16.0"
-axum-messages = "0.7.0"
+# axum-messages = "0.7.0"
+axum-messages = { path = "../../axum-messages" }
 base64 = "0.22.1"
 chrono = "0.4.38"
 deadpool = "0.12.1"


### PR DESCRIPTION
This allows us to display the messages with the error page handler, otherwise they get consumed too early.

See: https://github.com/maxcountryman/axum-messages/discussions/16